### PR TITLE
Simplifying admin landing page

### DIFF
--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -1,5 +1,133 @@
-{% extends "../../bootstrap_admin/templates/admin/index.html" %}
+{% extends "admin/base_site.html" %}
+{% load i18n admin_static %}
+
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/dashboard.css" %}" />{% endblock %}
+
+{% block coltype %}colMS{% endblock %}
+
+{% block bodyclass %}{{ block.super }} dashboard{% endblock %}
+
+{% block breadcrumbs %}{% endblock %}
+
 {% block content %}
-  {{ block.super }}
-  <iframe width="504" height="264" src="https://www.youtube.com/embed/CwHzGqliAzk" frameborder="0" allowfullscreen></iframe>
+
+<style>
+  .address-buttons {
+    margin: 0 auto;
+    margin-top: 1em;
+    margin-bottom: 1em;
+  }
+  .address-buttons.panel {
+    max-width: 30em;
+  }
+  .address-buttons .panel-heading {
+    font-size: 1.5em;
+  }
+  .address-buttons a.list-group-item {
+    font-size: 1.3em;
+  }
+  .address-buttons a.list-group-item span {
+    font-size: 1em;
+  }
+  .add-address-button {
+    margin:1em;
+  }
+</style>
+
+<div id="content-main" class="admin-landing-page">
+  <div class="panel panel-default address-buttons">
+    <div class="panel-heading">
+      My Addresses
+    </div>
+    <div class="list-group">
+      {% for address in request.user.address_set.all %}
+        <a href="/admin/world/address/{{ address.id }}/" class="list-group-item">
+          <span class="badge">
+            <span class="glyphicon glyphicon-pencil"></span>
+            Edit
+          </span>
+          {{ address.name }}
+        </a> 
+      {% endfor %}
+    </div>
+    <div class="add-address-button">
+      <a href="/admin/world/address/add/" class="btn btn-md btn-default" aria-label="..">
+        <span class="glyphicon glyphicon-plus"></span>
+        Add Address
+      </a>
+    </div>
+  </div>
+
+  <center>
+    <iframe width="504" height="264" src="https://www.youtube.com/embed/CwHzGqliAzk" frameborder="0" allowfullscreen></iframe>
+  </center>
+  
+  {% if app_list %}
+    <div class="panel panel-default" id="apps">
+      <div class="panel-heading">
+        <div class="btn-group apps-recent-actions">
+          <button class="btn btn-default" title="{% trans "Apps" %}">
+            <span class="glyphicon glyphicon-star-empty"></span>
+          </button>
+        </div>
+      </div>
+      <div class="table-responsive table-apps">
+        <table class="table table-bordered">
+          <thead>
+            <tr>
+              <th class="title-head-apps">
+                {% trans "Apps" %}
+              </th>
+              <th class="search-apps-models">
+                <form action="" method="get">
+                  <div class="wrapper">
+                    <span class="glyphicon glyphicon-search"></span>
+                    <input placeholder="{% trans "Search" %}" class="search form-control input-sm" type="input" name="q">
+                    <span class="remove-this label label-info"><span class="glyphicon glyphicon-remove"></span> <span class="text"></span></span>
+                  </div>
+                </form>
+              </th>
+              <th class="title-head-actions">{% trans "Action" %}</th>
+            </tr>
+          </thead>
+          <tbody class="list">
+            {% for app in app_list %}
+              {% cycle ' bg-colored' '' as rowcolors silent %}
+              {% for model in app.models %}
+                    <tr class="app-{{ app.app_label }}{{ rowcolors }}">
+                    {% if forloop.first %}
+                      <td rowspan="{{ app.models|length }}" class="app-name {% if forloop.parentloop.last %}last-app{% endif %}">
+                        <a href="{{ app.app_url }}" class="section" title="{% blocktrans with name=app.name %}Models in the {{ name }} application{% endblocktrans %}">{{ app.name }}</a>
+                      </td>
+                    {% endif %}
+
+                    <td class="model-name model-{{ model.object_name|lower }}">
+                      {% if forloop.first %}
+                        <a href="{{ app.app_url }}" class="extra-app-name" title="{% blocktrans with name=app.name %}Models in the {{ name }} application{% endblocktrans %}">{{ app.name }}</a>
+                      {% endif %}
+                      <a href="{% if model.admin_url %}{{ model.admin_url }}{% else %}#{% endif %}" title="{{ app.name }} &raquo; {{ model.name }}" {% if not model.admin_url %}class="disabled"{% endif %}>{{ model.name }}</a>
+                    </td>
+
+                    <td class="model-{{ model.object_name|lower }} actions">
+                      <div class="btn-group btn-group-justified btn-group-actions">
+                        <a href="{% if model.add_url %}{{ model.add_url }}{% endif %}" role="button" class="addlink btn {% if not model.add_url %}disabled{% endif %}" data-toggle="tooltip" data-placement="left" title="{% trans 'Add' %}"><span class="glyphicon glyphicon-plus"></span></a>
+                        <a href="{% if model.admin_url %}{{ model.admin_url }}{% endif %}" role="button" class="changelink btn {% if not model.admin_url %}disabled{% endif %}" title="{% trans 'Change' %}" data-toggle="tooltip" data-placement="left"><span class="glyphicon glyphicon-pencil"></span></a>
+                        <a href="#" class="btn search-in-model" data-toggle="tooltip" data-placement="left" title="{% trans 'Search' %}" data-model-name="{{ model.name }}" data-url-model-name="{{ model.admin_url }}"><span class="glyphicon glyphicon-search"></span></a>
+                      </div>
+                    </td>
+                  </tr>
+              {% endfor %}
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  {% else %}
+    <p>{% trans "You don't have permission to edit anything." %}</p>
+  {% endif %}
+</div>
 {% endblock %}
+
+{% block js %}
+  <script src="{% static "bootstrap_admin/js/dashboard.js" %}"></script>
+{% endblock js %}


### PR DESCRIPTION
This PR implements a simplified design for the Admin landing page. 
Users can see a list of their Addresses, with clear links to Add a new Address and to Edit existing Addresses. See photo below :)

As it is, the standard Django table appears below this simplified interface. The idea with this is that it can then be put inside an `if` block, say so that only Super Admins can see this table. 

The Youtube video is also easily removable. 

<img width="505" alt="screen shot 2015-09-23 at 18 57 39" src="https://cloud.githubusercontent.com/assets/4560746/10052047/0604f87a-6225-11e5-9851-3f741863d990.png">
